### PR TITLE
Renaming most references to 'traffic' to say 'events' instead

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # pathutils
 
-`pathutils` is a collection of utilities to gain user path insights from exported FullStory data.
+`pathutils` is a collection of utilities to gain user path insights from exported FullStory data..
 
 ## Local install
 
@@ -62,7 +62,7 @@ From here, you have several options to visualize your data set. In no particular
 ### Plot a diagram of top most visited URLs
 
 According to the way FullStory records user activity, a "visit" is defined as having a `navigate` event associated with the URL (so multiple visits can occur within the same session, or even consecutively). The list of URLs and corresponding visit counts can be produced by calling the `get_popular_urls.get_popular` function. The function parameters are:
-* `traffic` - dataframe containing the traffic data
+* `events` - dataframe containing the events data
 * `useResolvedUrls` - boolean flag. If `False`, standard page URLs will be used. If `True`, these page URLs can be grouped according to provided regex resolution rules (see URL Resolution section)
 * `limit_rows` - limit rows to a specific number of events (use full dataset if 0, which is default)
 
@@ -75,7 +75,7 @@ FullStory users often ask: what makes a good funnel? `pathutils` can help with p
 * `funurl` - URL that should be contained in the funnel
 * `funlen` - length of the funnels to consider
 * `useResolvedUrl`
-* `traffic`
+* `events`
 * `limit_rows`
 
 The function will return an unsorted list of all the funnels of specified length, and their frequency counts. The list can be sorted and trimmed by invoking `frequent_funnel.show_top_funnel`.
@@ -93,7 +93,7 @@ The arguments are slightly different for the command line version. The arguments
 ### Show conversion statistics for the specified funnel
 
 `funnel_stats.get_funnel_stats` function will return the number of sessions in which the user has navigated to a specific step of the funnel immediately after having navigated all the previous steps. For example, the returned count number for "Step 3" of a funnel will be the number of sessions that contain navigation sequence "Step 1, Step 2, Step 3". The function parameters are:
-* `traffic`
+* `events`
 * `funnel`
 * `useResolvedUrls`
 * `limit_rows`
@@ -104,7 +104,7 @@ The arguments are slightly different for the command line version. The arguments
 ### Generate session links for the specified funnel
 
 To generate links to sessions containing the funnel, invoke `analyze_traffic.get_sessions_for_funnel` function with the following parameters:
-* `traffic`
+* `events`
 * `funnel`
 * `useResolvedUrls`
 * `OrgId` - your FullStory OrgId
@@ -114,12 +114,12 @@ To generate links to sessions containing the funnel, invoke `analyze_traffic.get
 
 Session link tool can currently be used from code only (not as a command line tool).
 
-You can also get only the session links that contain a certain click type, by invoking `analyze_traffic.get_sessions_for_funnel_and_click`. The only differences from the above function are the following: `get_sessions_for_funnel_and_click` expects an additional `clicktype` parameter, and also a full dataset passed as `traffic` (as opposed to a `navigate`-only dataset).
+You can also get only the session links that contain a certain click type, by invoking `analyze_traffic.get_sessions_for_funnel_and_click`. The only differences from the above function are the following: `get_sessions_for_funnel_and_click` expects an additional `clicktype` parameter, and also a full dataset passed as `events` (as opposed to a `navigate`-only dataset).
 
 ### Generate inflow and outflow counts for the specified funnel
 
 You can also find most frequent entry and exit points for a funnel. Invoking `funnel_in_outs.get_in_outs` will return 2 dictionaries (ingress and egress). The ingress dictionary contains the URLs from which the users have entered the funnel, and the frequency count for each URL. The egress dictionary does the same for URLs to which the users exit after completing the funnel. The function parameters are:
-* `traffic`
+* `events`
 * `funnel`
 * `useResolvedUrls`
 * `limit_rows`
@@ -131,7 +131,7 @@ You can also find most frequent entry and exit points for a funnel. Invoking `fu
 
 Use the `sankey_funnel.plot_funnel` function to plot a Sankey diagram of funnel statistics and inflows/outflows with the following parameters:
 * `title` - plot title
-* `traffic`
+* `events`
 * `funnel`
 * `useResolvedUrls`
 * `cutoff` - maximum number of distinct input or output branches from each Sankey node (all additional branches get grouped into "Other" category)
@@ -142,7 +142,7 @@ Use the `sankey_funnel.plot_funnel` function to plot a Sankey diagram of funnel 
 ### View timing statistics for the specified funnel
 
 Once you have a funnel in mind, `pathutils` allows you to view timing information about it -- that is, gather insights into how much time users are spending at every step of the funnel before advancing to the next. Invoking `analyze_timing.get_timing_for_funnel` returns a complete set of timing results. The function parameters are:
- * `trafficfull`
+ * `eventsfull`
  * `funnel`
  * `useResolvedUrls`
 

--- a/pathing_demo.ipynb
+++ b/pathing_demo.ipynb
@@ -76,7 +76,7 @@
    ],
    "source": [
     "dffull = analyze_traffic.get_hauser_as_df(HAUSERDIR, navigate_only=False)\n",
-    "dffull = utils.preproc_traffic(dffull)\n",
+    "dffull = utils.preproc_events(dffull)\n",
     "#Optional: you can also filter your dataset to only include sessions with clicks of certain type\n",
     "#dffull = analyze_clicks.filter_dataset_by_clicktype(dffull, \"rage\")\n",
     "df = analyze_clicks.remove_non_navigation(dffull)\n",

--- a/pathing_demo.py
+++ b/pathing_demo.py
@@ -36,7 +36,7 @@ LIMITROWS = 0
 
 
 dffull = analyze_traffic.get_hauser_as_df(HAUSERDIR, navigate_only=False)
-dffull = utils.preproc_traffic(dffull)
+dffull = utils.preproc_events(dffull)
 #Optional: you can also filter your dataset to only include sessions with clicks of certain type
 #dffull = analyze_clicks.filter_dataset_by_clicktype(dffull, "rage")
 df = analyze_clicks.remove_non_navigation(dffull)

--- a/pathutils/analyze_clicks.py
+++ b/pathutils/analyze_clicks.py
@@ -53,7 +53,7 @@ def filter_dataset_by_clicktype(df: pd.DataFrame, clicktype: str) -> pd.DataFram
         print("Error: unknown click type: " + clicktype)
         return None
     si = build_clicktype_index(df)
-    filtered = utils.filter_traffic(df, session=si[clicktype])
+    filtered = utils.filter_events(df, session=si[clicktype])
     return filtered
 
 def remove_non_navigation(df: pd.DataFrame) -> pd.DataFrame:

--- a/pathutils/analyze_timing.py
+++ b/pathutils/analyze_timing.py
@@ -13,10 +13,10 @@ from pathutils import analyze_clicks, analyze_traffic, manage_resolutions, url_r
 
 EVENTSTART = "EventStart"
 
-def get_timing_for_funnel(trafficfull: DataFrame, funnel: list, useResolvedUrls: bool) -> list:
+def get_timing_for_funnel(eventsfull: DataFrame, funnel: list, useResolvedUrls: bool) -> list:
     """Get a list of funnel step times (amounts of time users spend before navigating to next step) for a funnel
 
-    :param trafficfull: full traffic DataFrame (that includes non-navigate events)
+    :param eventsfull: full events DataFrame (that includes non-navigate events)
     :param funnel: funnel of interest
     :param useResolvedUrls: indicates whether original or resolved URLs should be used
     :return: list of funnel step times for each step
@@ -24,18 +24,18 @@ def get_timing_for_funnel(trafficfull: DataFrame, funnel: list, useResolvedUrls:
     funneltimes = []
     for i in range(len(funnel)):
         funneltimes.append([])
-    traffic = analyze_clicks.remove_non_navigation(trafficfull)
+    events = analyze_clicks.remove_non_navigation(eventsfull)
     if useResolvedUrls:
         columnToUse = analyze_traffic.RESOLVEDURL
     else:
         columnToUse = analyze_traffic.PAGEURL
     if useResolvedUrls:
-        url_regex_resolver.resolve_urls(traffic, manage_resolutions.get_regex_dict(), analyze_traffic.PAGEURL, analyze_traffic.RESOLVEDURL)
-    si = analyze_traffic.build_session_index(traffic, columnToUse)
+        url_regex_resolver.resolve_urls(events, manage_resolutions.get_regex_dict(), analyze_traffic.PAGEURL, analyze_traffic.RESOLVEDURL)
+    si = analyze_traffic.build_session_index(events, columnToUse)
     sessFound = analyze_traffic.get_unordered_sessions_for_funnel(si, funnel)
-    sessOrdered = analyze_traffic.get_sessions_with_ordered(traffic, sessFound, funnel, columnToUse, strict=True)
+    sessOrdered = analyze_traffic.get_sessions_with_ordered(events, sessFound, funnel, columnToUse, strict=True)
     for sid in sessOrdered:
-        sess_df = traffic.loc[sid]
+        sess_df = events.loc[sid]
         indices = analyze_traffic.get_sublist_indices(funnel, sess_df[columnToUse].tolist(), True)
         for index in indices:
             timestamps = []

--- a/pathutils/funnel_in_outs.py
+++ b/pathutils/funnel_in_outs.py
@@ -17,22 +17,22 @@ def print_in_outs(folder, funnelFile, useResolvedUrls, limit_rows, doPlot):
     with open(funnelFile, "r") as fread:
         tFile = json.load(fread)
     funnel = tFile["funnel"]
-    traffic = analyze_traffic.get_hauser_as_df(folder)
-    traffic = utils.preproc_traffic(traffic)
-    ingressCounts, egressCounts = get_in_outs(traffic, funnel, useResolvedUrls, limit_rows)
+    events = analyze_traffic.get_hauser_as_df(folder)
+    events = utils.preproc_events(events)
+    ingressCounts, egressCounts = get_in_outs(events, funnel, useResolvedUrls, limit_rows)
     if not doPlot:
         analyze_traffic.print_in_outs(ingressCounts, egressCounts)
     else:
         analyze_traffic.plot_in_outs(ingressCounts, egressCounts)
 
 
-def get_in_outs(traffic: DataFrame, funnel: list, useResolvedUrls: bool, limit_rows: int = 0) -> (dict, dict):
+def get_in_outs(events: DataFrame, funnel: list, useResolvedUrls: bool, limit_rows: int = 0) -> (dict, dict):
     """Get information about inflows and outflows for a funnel
 
-    :param traffic: traffic DataFrame
+    :param events: events DataFrame
     :param funnel: funnel of interest
     :param useResolvedUrls: indicates whether original or resolved URLs should be used
-    :param limit_rows: number of rows of traffic DataFrame to use (use all rows if 0)
+    :param limit_rows: number of rows of events DataFrame to use (use all rows if 0)
     :return: a pair of dictionaries, with inflow and outflow URL frequency counts
     """
     if useResolvedUrls:
@@ -40,12 +40,11 @@ def get_in_outs(traffic: DataFrame, funnel: list, useResolvedUrls: bool, limit_r
     else:
         columnToUse = analyze_traffic.PAGEURL
     if limit_rows != 0:
-        traffic = traffic.head(limit_rows)
+        events = events.head(limit_rows)
     if useResolvedUrls:
-        url_regex_resolver.resolve_urls(traffic, manage_resolutions.get_regex_dict(), analyze_traffic.PAGEURL, analyze_traffic.RESOLVEDURL)
-    si = analyze_traffic.build_session_index(traffic, columnToUse)
-    ingressCounts, egressCounts = analyze_traffic.get_funnel_in_outs(traffic, si, funnel, columnToUse, analyze_traffic.REFERAL)
-    print("done generating inflows and outflows") # this for a  better jupyter notebook experience
+        url_regex_resolver.resolve_urls(events, manage_resolutions.get_regex_dict(), analyze_traffic.PAGEURL, analyze_traffic.RESOLVEDURL)
+    si = analyze_traffic.build_session_index(events, columnToUse)
+    ingressCounts, egressCounts = analyze_traffic.get_funnel_in_outs(events, si, funnel, columnToUse, analyze_traffic.REFERAL)
     return ingressCounts, egressCounts
 
 if __name__ == "__main__":

--- a/pathutils/funnel_stats.py
+++ b/pathutils/funnel_stats.py
@@ -17,19 +17,19 @@ def print_in_outs(folder, funnelFile, useResolvedUrls, limit_rows):
     with open(funnelFile, "r") as fread:
         tFile = json.load(fread)
     funnel = tFile["funnel"]
-    traffic = analyze_traffic.get_hauser_as_df(folder)
-    traffic = utils.preproc_traffic(traffic)
-    funnelCounts = get_funnel_stats(traffic, funnel, useResolvedUrls, limit_rows)
+    events = analyze_traffic.get_hauser_as_df(folder)
+    events = utils.preproc_events(events)
+    funnelCounts = get_funnel_stats(events, funnel, useResolvedUrls, limit_rows)
     print_funnelcounts(funnelCounts)
 
 
-def get_funnel_stats(traffic: DataFrame, funnel: list, useResolvedUrls: bool, limit_rows: int = 0) -> list:
+def get_funnel_stats(events: DataFrame, funnel: list, useResolvedUrls: bool, limit_rows: int = 0) -> list:
     """Get conversion statistics for a funnel
 
-    :param traffic: traffic DataFrame
+    :param events: events DataFrame
     :param funnel: funnel of interest
     :param useResolvedUrls: indicates whether original or resolved URLs should be used
-    :param limit_rows: number of rows of traffic DataFrame to use (use all rows if 0)
+    :param limit_rows: number of rows of events DataFrame to use (use all rows if 0)
     :return: sorted list of funnel conversions by step
     """
     if useResolvedUrls:
@@ -37,11 +37,11 @@ def get_funnel_stats(traffic: DataFrame, funnel: list, useResolvedUrls: bool, li
     else:
         columnToUse = analyze_traffic.PAGEURL
     if limit_rows != 0:
-        traffic = traffic.head(limit_rows)
+        events = events.head(limit_rows)
     if useResolvedUrls:
-        url_regex_resolver.resolve_urls(traffic, manage_resolutions.get_regex_dict(), analyze_traffic.PAGEURL, analyze_traffic.RESOLVEDURL)
-    si = analyze_traffic.build_session_index(traffic, columnToUse)
-    funnelCounts = analyze_traffic.get_funnel_conversion_stats(traffic, si, funnel, columnToUse)
+        url_regex_resolver.resolve_urls(events, manage_resolutions.get_regex_dict(), analyze_traffic.PAGEURL, analyze_traffic.RESOLVEDURL)
+    si = analyze_traffic.build_session_index(events, columnToUse)
+    funnelCounts = analyze_traffic.get_funnel_conversion_stats(events, si, funnel, columnToUse)
     funnelCounts = list(funnelCounts)
     return funnelCounts
 

--- a/pathutils/get_popular_urls.py
+++ b/pathutils/get_popular_urls.py
@@ -13,15 +13,15 @@ from pathutils import analyze_traffic, utils, url_regex_resolver, manage_resolut
 
 def print_popular(folder, useResolvedUrls, limit_rows, topCounts):
     df = analyze_traffic.get_hauser_as_df(folder)
-    df = utils.preproc_traffic(df)
+    df = utils.preproc_events(df)
     urlCounts = get_popular(df, useResolvedUrls, limit_rows)
     print_top_url_counts(urlCounts, topCounts)
 
 
-def get_popular(traffic: pd.DataFrame, useResolvedUrls: bool, limit_rows: int = 0) -> dict:
+def get_popular(events: pd.DataFrame, useResolvedUrls: bool, limit_rows: int = 0) -> dict:
     """Returns a dictionary of visited URLs and visit counts for each URL
 
-    :param traffic: traffic DataFrame
+    :param events: events DataFrame
     :param useResolvedUrls: boolean indicating whether original or resolved URLs should be used
     :param limit_rows: number of rows from the original DataFrame to use (if 0, then use entire DataFrame)
     :return:
@@ -31,10 +31,10 @@ def get_popular(traffic: pd.DataFrame, useResolvedUrls: bool, limit_rows: int = 
     else:
         columnToUse = analyze_traffic.PAGEURL
     if limit_rows != 0:
-        traffic = traffic.head(limit_rows)
+        events = events.head(limit_rows)
     if useResolvedUrls:
-        url_regex_resolver.resolve_urls(traffic, manage_resolutions.get_regex_dict(), analyze_traffic.PAGEURL, analyze_traffic.RESOLVEDURL)
-    si = analyze_traffic.build_session_index(traffic, columnToUse)
+        url_regex_resolver.resolve_urls(events, manage_resolutions.get_regex_dict(), analyze_traffic.PAGEURL, analyze_traffic.RESOLVEDURL)
+    si = analyze_traffic.build_session_index(events, columnToUse)
     urlCounts = analyze_traffic.get_counts_for_url(si)
     return urlCounts
 

--- a/pathutils/sankey_funnel.py
+++ b/pathutils/sankey_funnel.py
@@ -27,11 +27,11 @@ def show_sankey(folder, funnelFile, useResolvedUrls, limitBranches, title):
     with open(funnelFile, "r") as fread:
         tFile = json.load(fread)
     funnel = tFile["funnel"]
-    traffic = analyze_traffic.get_hauser_as_df(folder)
-    traffic = utils.preproc_traffic(traffic)
-    plot_funnel(title, traffic, funnel, useResolvedUrls, limitBranches)
+    events = analyze_traffic.get_hauser_as_df(folder)
+    events = utils.preproc_events(events)
+    plot_funnel(title, events, funnel, useResolvedUrls, limitBranches)
 
-def get_funnel_lists(title: str, traffic: pd.DataFrame, funnel: list, useResolvedUrls: bool, cutoff: int=10):
+def get_funnel_lists(title: str, events: pd.DataFrame, funnel: list, useResolvedUrls: bool, cutoff: int=10):
     labels = []
     colors = []
     sources = []
@@ -54,7 +54,7 @@ def get_funnel_lists(title: str, traffic: pd.DataFrame, funnel: list, useResolve
 
     nodecount = len(funnel)
 
-    funnel_counts = get_funnel_stats(traffic, funnel, useResolvedUrls, 0)
+    funnel_counts = get_funnel_stats(events, funnel, useResolvedUrls, 0)
     totalIn = funnel_counts[0][1]
 
     for i in range(len(funnel_counts) - 1):
@@ -64,7 +64,7 @@ def get_funnel_lists(title: str, traffic: pd.DataFrame, funnel: list, useResolve
 
     # Add funnel sources
     subfunnel = funnel[:1]
-    ingress, egress = get_in_outs(traffic, subfunnel, useResolvedUrls, 0)
+    ingress, egress = get_in_outs(events, subfunnel, useResolvedUrls, 0)
     sortIn = sorted_dict_items(ingress, True)
     sortIn = sortIn[:cutoff]
     for input in sortIn:
@@ -87,7 +87,7 @@ def get_funnel_lists(title: str, traffic: pd.DataFrame, funnel: list, useResolve
     # Add funnel sinks
     for j in range(1, len(funnel) + 1):
         subfunnel = funnel[:j]
-        ingress, egress = get_in_outs(traffic, subfunnel, useResolvedUrls, 0)
+        ingress, egress = get_in_outs(events, subfunnel, useResolvedUrls, 0)
         sortOut = sorted_dict_items(egress, True)
         sortOutCut = sortOut[:cutoff]
         nextStepInFun = False
@@ -132,17 +132,17 @@ def get_funnel_lists(title: str, traffic: pd.DataFrame, funnel: list, useResolve
     return labels, colors, sources, targets, values, title
 
 
-def plot_funnel(title: str, traffic: pd.DataFrame, funnel: list, useResolvedUrls: bool, cutoff: int=10):
+def plot_funnel(title: str, events: pd.DataFrame, funnel: list, useResolvedUrls: bool, cutoff: int=10):
     """Plot sankey diagram for a funnel
 
     :param title: title for the sankey diagram
-    :param traffic: traffic dataframe
+    :param events: events dataframe
     :param funnel: funnel to be plotted
     :param useResolvedUrls: indicates whether original or resolved URLs should be used
     :param cutoff: number of inflow/outflow nodes to plot for each sankey node (all remaining nodes get grouped into Other)
     :return:
     """
-    labels, colors, sources, targets, values, title = get_funnel_lists(title, traffic, funnel, useResolvedUrls, cutoff)
+    labels, colors, sources, targets, values, title = get_funnel_lists(title, events, funnel, useResolvedUrls, cutoff)
 
     fig = gobj.Figure(data=[gobj.Sankey(
         arrangement="freeform",

--- a/pathutils/url_regex_resolver.py
+++ b/pathutils/url_regex_resolver.py
@@ -7,8 +7,8 @@ import pandas as pd
 import re
 
 
-def resolve_urls(traffic: pd.DataFrame, toReplace: dict, fromCol: str, toCol: str):
-    traffic.loc[:,toCol] = traffic.apply(create_resolved_url, axis=1, args=(toReplace, fromCol))
+def resolve_urls(events: pd.DataFrame, toReplace: dict, fromCol: str, toCol: str):
+    events.loc[:,toCol] = events.apply(create_resolved_url, axis=1, args=(toReplace, fromCol))
 
 
 def create_resolved_url(row: pd.Series, toReplace: dict, fromCol: str):


### PR DESCRIPTION
Per Patrick's suggestion, I've renamed almost all references to `traffic` in function and parameter names to `events`, as he felt that it would improve clarity, since we are planning to talk about event streams in our video. The only thing that wasn't renamed is `analyze_traffic` module.